### PR TITLE
use the same version format for the twig-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/slack-notifier": "5.2.*",
         "symfony/string": "5.2.*",
         "symfony/translation": "5.2.*",
-        "symfony/twig-bundle": "^5.2",
+        "symfony/twig-bundle": "5.2.*",
         "symfony/validator": "5.2.*",
         "symfony/webpack-encore-bundle": "^1.9",
         "symfony/workflow": "5.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c7ade66657cd11c74919a833d815e26",
+    "content-hash": "bde90eb0d23e005d2104f3f9da6a3344",
     "packages": [
         {
             "name": "api-platform/core",


### PR DESCRIPTION
all the rest of the symfony dependancies in require section use `5.2.*` for version constraint