### PR TITLE
Step 9.1 | Fix EasyAdmin redirect to Conference

### DIFF
--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -7,7 +7,7 @@ use App\Entity\Conference;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -18,9 +18,9 @@ class DashboardController extends AbstractDashboardController
      */
     public function index(): Response
     {
-        $routeBuilder = $this->get(CrudUrlGenerator::class)->build();
+        $routeBuilder = $this->get(AdminUrlGenerator::class);
         $url = $routeBuilder->setController(ConferenceCrudController::class)->generateUrl();
-
+        
         return $this->redirect($url);
     }
 


### PR DESCRIPTION
This is my first approach to Symfony. I was reading the book to start learning it (Step 9.1, implementing the redirect from the Dashboard index to the Conference page).
I couldn't find a solution because with the official code from line 21 to 24 I got an exception:
"Argument 1 passed to EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator::setController() must be of the type string, null given, called in /home/developer/work/guestbook/vendor/twig/twig/src/Extension/CoreExtension.php on line 1544"

After some research (apparently nobody else had this issue) I found something related here regarding some deprecation:
https://github.com/EasyCorp/EasyAdminBundle/blob/master/UPGRADE.md right under "Deprecated eaContext query parameter"

Just wondering if it's just me who couldn't make it work or is it because of some EasyAdmin updates?
In any case, it's a big opportunity to learn. Thanks in advance.